### PR TITLE
Added NCM source

### DIFF
--- a/autoload/cm/sources/necovim.vim
+++ b/autoload/cm/sources/necovim.vim
@@ -1,0 +1,12 @@
+"=============================================================================
+" FILE: necovim.vim (NCM source)
+" AUTHOR:  Karl Yngve Lervåg <karl.yngve@gmail.com>
+" License: MIT license
+"=============================================================================
+
+function! cm#sources#necovim#refresh(opt, ctx)
+  let startcol = necovim#get_complete_position(a:ctx.typed)
+  let base = strpart(a:ctx.typed, startcol)
+  let cnd = necovim#gather_candidates(a:ctx.typed, base)
+  call cm#complete(a:opt.name, a:ctx, startcol+1, cnd)
+endfunction

--- a/autoload/necovim.vim
+++ b/autoload/necovim.vim
@@ -60,7 +60,7 @@ function! necovim#gather_candidates(input, complete_str) abort
       let keyword.abbr = prefix .
             \ get(keyword, 'abbr', keyword.word)[2:]
     endfor
-  elseif cur_text =~# '\<let\S'
+  elseif cur_text =~# '\<let\s'
     let list = necovim#helper#let(cur_text, a:complete_str)
   elseif cur_text =~# '\<has([''"]\w*$'
     " Features.

--- a/plugin/necovim.vim
+++ b/plugin/necovim.vim
@@ -29,6 +29,17 @@ set cpo&vim
 augroup necovim
   autocmd!
   autocmd BufWritePost,FileType vim call necovim#helper#make_cache()
+
+  " Register source for NCM
+  autocmd User CmSetup call cm#register_source({
+        \ 'name': 'vim',
+        \ 'abbreviation': 'vim',
+        \ 'priority': 9,
+        \ 'scoping': 1,
+        \ 'scopes': ['vim'],
+        \ 'cm_refresh': 'cm#sources#necovim#refresh',
+        \ 'cm_refresh_patterns': ['\w\+\.$'],
+        \ })
 augroup END
 
 let g:loaded_necovim = 1


### PR DESCRIPTION
The first commit adds a necovim source for nvim-completion-manager (as promised [here](https://github.com/roxma/nvim-completion-manager/issues/70#issuecomment-296418349)).

The second commit fixes a minor bug in a regexp, I think. Please review; if I'm mistaken I will of course update correspondingly.